### PR TITLE
Fix prefix assertion typo

### DIFF
--- a/src/libmccs/src/lib.rs
+++ b/src/libmccs/src/lib.rs
@@ -45,7 +45,7 @@ lazy_static::lazy_static! {
             Err(_) => PathBuf::from(DEFAULT_MCCS_PREFIX),
         }, |p| {
             let path = PathBuf::from(p);
-            assert!(path.is_dir(), "{path:?} is not a directly");
+            assert!(path.is_dir(), "{path:?} is not a directory");
             path
         })
     };


### PR DESCRIPTION
## Summary
- fix small typo in `MCCS_PREFIX` assertion

## Testing
- `cargo fmt` *(failed: could not download toolchain)*
- `cargo test` *(failed: could not download toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_685ba7862c5c8322be3694add5e769ef